### PR TITLE
Add PVS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "Rxh7p"
-version = "1.0.0"
+version = "1.2.0"
 dependencies = [
  "chess",
  "fnv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Rxh7p"
-version = "1.0.0"
+version = "1.2.0"
 edition = "2024"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Benchmarking can be done using cutechess-cli.
 
 ```sh
 cutechess-cli
-  -engine name=new proto=uci cmd=new -engine name=old proto=uci cmd=old -openings file=openings order=random policy=round plies=14 -concurrency 8 -ratinginterval 2 -rounds 500 -games 2 -each tc=30+0.2 ponder -sprt elo0=0 elo1=10 alpha=0.05 beta=0.05
+  -engine name=new proto=uci cmd=new -engine name=old proto=uci cmd=old -openings file=openings order=random policy=round plies=14 -concurrency 8 -ratinginterval 2 -rounds 500 -games 2 -each tc=30+0.5 ponder -sprt elo0=0 elo1=10 alpha=0.05 beta=0.05
 ```
 
 Explaination:
@@ -21,7 +21,7 @@ Explaination:
 - `-rounds 500`: play for 500 rounds each two games.
 - `-games 2`: play for 500 rounds each two games.
 - `-each`: apply the following settings to both engines.
-- `tc=30+0.2`: play 30+0.2s.
+- `tc=30+0.5`: play 30+0.5s.
 - `ponder`: allow engines to ponder during opponent moves.
 - `sprt elo0=0 elo1=150 alpha=0.05 beta=0.05`: sequential probability ratio test. Hypthoesis H1 is that engine A is stronger than engine B by at least elo0, hypthesis H0 is that engine A is not stronger than B by at least elo1. If either H0 or H1 are fulfilled with error in alpha and beta the match is stopped.
 
@@ -129,6 +129,9 @@ Pieces of knowledge interesting to anyone reading, myself included.
 - https://web.archive.org/web/20071030220825/http://www.brucemo.com/compchess/programming/pvs.htm
 - https://www.chessprogramming.org/Triangular_PV-Table
 
+- https://www.chessprogramming.org/Material#Balance
+- https://www.chessprogramming.org/CPW-Engine_recognize
+- https://www.chessprogramming.org/Draw_Evaluation
 - https://www.chessprogramming.org/Lazy_Evaluation
 - https://zwischenzug.substack.com/p/centipawns-suck
 - https://www.chessprogramming.org/History_Leaf_Pruning

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Pieces of knowledge interesting to anyone reading, myself included.
 
 <details>
 
+- https://www.chessprogramming.org/Sequential_Probability_Ratio_Test
 - https://web.archive.org/web/20071030220825/http://www.brucemo.com/compchess/programming/pvs.htm
 - https://www.chessprogramming.org/Triangular_PV-Table
 

--- a/README.md
+++ b/README.md
@@ -10,15 +10,16 @@ Benchmarking can be done using cutechess-cli.
 
 ```sh
 cutechess-cli
-  -engine name=new proto=uci cmd=new -engine name=old proto=uci cmd=old -openings file=openings -concurrency 8 -ratinginterval 2 -games 500 -repeat -each tc=10+0.1 ponder -recover -sprt elo0=0 elo1=10 alpha=0.05 beta=0.05
+  -engine name=new proto=uci cmd=new -engine name=old proto=uci cmd=old -openings file=openings order=random policy=round plies=8 -concurrency 8 -ratinginterval 2 -rounds 300 -games 2 -each tc=10+0.1 ponder -recover -sprt elo0=0 elo1=10 alpha=0.05 beta=0.05
 ```
 
 Explaination:
 
-- `-openings file=openings`: play starting positions from the opening book.
+- `-openings file=openings order=random policy=round plies=8`: play a random starting position for eight plies from the opening book and swap each round.
 - `-concurrency 8`: play eight games in parallel.
 - `-ratinginterval 2`: print the rating every two finished games.
-- `-games 500`: play for 500 games.
+- `-rounds 300`: play for 300 rounds each two games.
+- `-games 2`: play for 300 rounds each two games.
 - `-each`: apply the following settings to both engines.
 - `tc=10+0.1`: play 10+0.1s.
 - `ponder`: allow engines to ponder during opponent moves.
@@ -75,6 +76,8 @@ Pieces of knowledge interesting to anyone reading, myself included.
 - https://www.chessprogramming.org/Alpha-Beta#Negamax_Framework
 - https://www.chessprogramming.org/Transposition_Table
 - https://www.chessprogramming.org/Iterative_Deepening
+- https://www.chessprogramming.org/Principal_Variation_Search
+- https://www.chessprogramming.org/Null_Window
 
 </details>
 
@@ -124,12 +127,13 @@ Pieces of knowledge interesting to anyone reading, myself included.
 
 - https://web.archive.org/web/20071030220825/http://www.brucemo.com/compchess/programming/pvs.htm
 - https://www.chessprogramming.org/Triangular_PV-Table
-- https://www.chessprogramming.org/Principal_Variation_Search
 
+- https://www.chessprogramming.org/Lazy_Evaluation
 - https://zwischenzug.substack.com/p/centipawns-suck
 - https://www.chessprogramming.org/History_Leaf_Pruning
 - https://www.chessprogramming.org/Late_Move_Reductions
 - https://www.chessprogramming.org/History_Heuristic
+- https://www.chessprogramming.org/Null_Move_Pruning
 - Implement endgame tablebases
 - https://www.chessprogramming.org/CLOP
 - https://www.chessprogramming.org/Lazy_SMP

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Benchmarking can be done using cutechess-cli.
 
 ```sh
 cutechess-cli
-  -engine name=new proto=uci cmd=new -engine name=old proto=uci cmd=old -openings file=openings order=random policy=round plies=8 -concurrency 8 -ratinginterval 2 -rounds 300 -games 2 -each tc=10+0.1 ponder -sprt elo0=0 elo1=10 alpha=0.05 beta=0.05
+  -engine name=new proto=uci cmd=new -engine name=old proto=uci cmd=old -openings file=openings order=random policy=round plies=14 -concurrency 8 -ratinginterval 2 -rounds 500 -games 2 -each tc=30+0.2 ponder -sprt elo0=0 elo1=10 alpha=0.05 beta=0.05
 ```
 
 Explaination:
@@ -18,10 +18,10 @@ Explaination:
 - `-openings file=openings order=random policy=round plies=14`: play a random starting position for 14 plies from the opening book and swap each round.
 - `-concurrency 8`: play eight games in parallel.
 - `-ratinginterval 2`: print the rating every two finished games.
-- `-rounds 300`: play for 300 rounds each two games.
-- `-games 2`: play for 300 rounds each two games.
+- `-rounds 500`: play for 500 rounds each two games.
+- `-games 2`: play for 500 rounds each two games.
 - `-each`: apply the following settings to both engines.
-- `tc=10+0.1`: play 10+0.1s.
+- `tc=30+0.2`: play 30+0.2s.
 - `ponder`: allow engines to ponder during opponent moves.
 - `sprt elo0=0 elo1=150 alpha=0.05 beta=0.05`: sequential probability ratio test. Hypthoesis H1 is that engine A is stronger than engine B by at least elo0, hypthesis H0 is that engine A is not stronger than B by at least elo1. If either H0 or H1 are fulfilled with error in alpha and beta the match is stopped.
 

--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ Benchmarking can be done using cutechess-cli.
 
 ```sh
 cutechess-cli
-  -engine name=new proto=uci cmd=new -engine name=old proto=uci cmd=old -openings file=openings order=random policy=round plies=8 -concurrency 8 -ratinginterval 2 -rounds 300 -games 2 -each tc=10+0.1 ponder -recover -sprt elo0=0 elo1=10 alpha=0.05 beta=0.05
+  -engine name=new proto=uci cmd=new -engine name=old proto=uci cmd=old -openings file=openings order=random policy=round plies=8 -concurrency 8 -ratinginterval 2 -rounds 300 -games 2 -each tc=10+0.1 ponder -sprt elo0=0 elo1=10 alpha=0.05 beta=0.05
 ```
 
 Explaination:
 
-- `-openings file=openings order=random policy=round plies=8`: play a random starting position for eight plies from the opening book and swap each round.
+- `-openings file=openings order=random policy=round plies=14`: play a random starting position for 14 plies from the opening book and swap each round.
 - `-concurrency 8`: play eight games in parallel.
 - `-ratinginterval 2`: print the rating every two finished games.
 - `-rounds 300`: play for 300 rounds each two games.
@@ -23,7 +23,6 @@ Explaination:
 - `-each`: apply the following settings to both engines.
 - `tc=10+0.1`: play 10+0.1s.
 - `ponder`: allow engines to ponder during opponent moves.
-- `-recover`: attempt to restart engines on crash instead of forfeiting the match.
 - `sprt elo0=0 elo1=150 alpha=0.05 beta=0.05`: sequential probability ratio test. Hypthoesis H1 is that engine A is stronger than engine B by at least elo0, hypthesis H0 is that engine A is not stronger than B by at least elo1. If either H0 or H1 are fulfilled with error in alpha and beta the match is stopped.
 
 # Bibliography
@@ -78,6 +77,7 @@ Pieces of knowledge interesting to anyone reading, myself included.
 - https://www.chessprogramming.org/Iterative_Deepening
 - https://www.chessprogramming.org/Principal_Variation_Search
 - https://www.chessprogramming.org/Null_Window
+- https://en.wikipedia.org/wiki/Principal_variation_search
 
 </details>
 

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -75,7 +75,7 @@ impl Engine {
 
         for depth in 1.. {
             // i64::MIN + 1 to avoid overflow when negating the value.
-            let new_eval = self.negamax(self.board, &searchmoves, i64::MIN + 1, i64::MAX, depth);
+            let new_eval = self.pvs(self.board, &searchmoves, i64::MIN + 1, i64::MAX, depth);
 
             // Only set the PV search depth to the current depth and eval to new_eval if the search
             // was not interrupted.
@@ -133,7 +133,7 @@ impl Engine {
     }
 
     /// Checks if a stop condition for search is fulfilled.
-    fn stop_negamax(&mut self) -> bool {
+    fn stop_search(&mut self) -> bool {
         // Received ponderhit command.
         if self.ponderhit_rx.try_recv().is_ok() {
             self.search.ponder = false;
@@ -181,8 +181,8 @@ impl Engine {
         false
     }
 
-    /// Performs a negamax search on a given board.
-    fn negamax(
+    /// Performs a PVS search on a given board.
+    fn pvs(
         &mut self,
         board: Board,
         searchmoves: &Option<Vec<ChessMove>>,
@@ -190,7 +190,7 @@ impl Engine {
         beta: i64,
         depth: u16,
     ) -> Option<i64> {
-        if self.stop_negamax() {
+        if self.stop_search() {
             return None;
         }
 
@@ -236,9 +236,10 @@ impl Engine {
             &orderer::all(&board, depth, &self.tt, self.board_ply, self.search.ply)
         };
 
+        let mut move_number = 1;
+        let mut first_search = true;
         let mut max_eval = i64::MIN + 1;
         let mut best_mv = None;
-        let mut move_number = 1;
         for mv in moves {
             // Send current searching move for the top level of the search.
             if self.search.ply == 0 {
@@ -260,8 +261,23 @@ impl Engine {
             self.position_stack.push((new_board, irreversible));
             self.search.ply += 1;
 
-            // Evaluate new position.
-            let new_eval = self.negamax(new_board, &None, -beta, -alpha, depth - 1);
+            let mut new_eval;
+            if first_search {
+                // Evaluate new position fully if first search.
+                new_eval = self.pvs(new_board, &None, -beta, -alpha, depth - 1);
+                first_search = false;
+            } else {
+                // Perform null-window search on following searches.
+                new_eval = self.pvs(new_board, &None, -alpha - 1, -alpha, depth - 1);
+
+                // If the null-window search failed high, repeat with a full search.
+                // Inverse result due to symmetry.
+                if let Some(eval) = new_eval
+                    && -eval > alpha
+                {
+                    new_eval = self.pvs(new_board, &None, -beta, -alpha, depth - 1);
+                }
+            }
 
             // Pop new position from the stack and decrement search ply.
             self.position_stack.pop();
@@ -283,7 +299,7 @@ impl Engine {
                     break;
                 }
             } else {
-                // If negamax returns None, search was cancelled, return up the chain.
+                // If pvs returns None, search was cancelled, return up the chain.
                 return None;
             }
         }
@@ -297,7 +313,7 @@ impl Engine {
         let tt_entry = TtEntry::new(
             flag,
             depth,
-            best_mv.expect("Negamax didn't find any move to make."),
+            best_mv.expect("PVS didn't find any move to make."),
             side,
             max_eval,
         );

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -236,21 +236,10 @@ impl Engine {
             &orderer::all(&board, depth, &self.tt, self.board_ply, self.search.ply)
         };
 
-        //let mut move_number = 1;
         let mut first_search = true;
         let mut max_eval = i64::MIN + 1;
         let mut best_mv = None;
         for mv in moves {
-            // Send current searching move for the top level of the search.
-            /*
-            if self.search.ply == 0 {
-                self.message_tx
-                    .send(UciSenderMessage::CurrMoveInfo(*mv, move_number))
-                    .expect("Failed to send message to UCI sender.");
-                move_number += 1;
-            }
-            */
-
             let new_board = board.make_move_new(*mv);
 
             // Add new position to and increment search ply.

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -261,8 +261,7 @@ impl Engine {
                 // Inverse result due to symmetry.
                 if let Some(eval) = new_eval
                     && -eval > alpha
-                    && beta != i64::MIN + 1
-                    && beta - alpha > 1
+                    && -eval < beta
                 {
                     new_eval = self.pvs(new_board, &None, -beta, -alpha, depth - 1);
                 }

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -261,6 +261,7 @@ impl Engine {
                 // Inverse result due to symmetry.
                 if let Some(eval) = new_eval
                     && -eval > alpha
+                    && beta != i64::MIN + 1
                     && beta - alpha > 1
                 {
                     new_eval = self.pvs(new_board, &None, -beta, -alpha, depth - 1);

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -254,7 +254,10 @@ impl Engine {
                 // If the null-window search failed high, repeat with a full search.
                 // Inverse result due to symmetry.
                 if let Some(eval) = new_eval
+                // Prune non-PV moves. In rare cases this condition is true for PV moves, but the
+                // chance is negligible.
                     && -eval > alpha
+                    && -eval < beta
                 {
                     new_eval = self.pvs(new_board, &None, -beta, -alpha, depth - 1);
                 }

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -261,6 +261,7 @@ impl Engine {
                 // Inverse result due to symmetry.
                 if let Some(eval) = new_eval
                     && -eval > alpha
+                    && beta - alpha > 1
                 {
                     new_eval = self.pvs(new_board, &None, -beta, -alpha, depth - 1);
                 }

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -24,9 +24,6 @@ pub struct Engine {
     pub(super) position_stack: Vec<(Board, bool)>,
 
     // TODO: 50 move rule.
-    /// Ply of played moves. Needed to access previously computed TT entries in next search.
-    pub(super) board_ply: u16,
-
     /// Information about the current search.
     pub(super) search: Search,
 
@@ -51,7 +48,6 @@ impl Engine {
             board,
             tt: TT::new(),
             position_stack: vec![(board, true)],
-            board_ply: 0,
             search: Search::default(),
             message_tx,
             stop_rx,
@@ -118,9 +114,7 @@ impl Engine {
 
         let mut idx = 0;
         // Traverse the TT until the searched depth and gather the PV.
-        while let Some(entry) = self
-            .tt
-            .get(temp_board.get_hash() + self.board_ply as u64 + idx)
+        while let Some(entry) = self.tt.get(temp_board.get_hash())
             && idx < depth as u64
         {
             pv.push(entry.mv);
@@ -213,7 +207,7 @@ impl Engine {
         }
 
         let prev_alpha = alpha;
-        let hash = board.get_hash() + self.board_ply as u64 + self.search.ply as u64;
+        let hash = board.get_hash();
         let side = board.side_to_move();
 
         // If viable entry exists return evaluation.
@@ -233,7 +227,7 @@ impl Engine {
         let moves = if let Some(searchmoves) = searchmoves {
             searchmoves
         } else {
-            &orderer::all(&board, depth, &self.tt, self.board_ply, self.search.ply)
+            &orderer::all(&board, depth, &self.tt)
         };
 
         let mut first_search = true;
@@ -261,7 +255,6 @@ impl Engine {
                 // Inverse result due to symmetry.
                 if let Some(eval) = new_eval
                     && -eval > alpha
-                    && -eval < beta
                 {
                     new_eval = self.pvs(new_board, &None, -beta, -alpha, depth - 1);
                 }

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -236,18 +236,20 @@ impl Engine {
             &orderer::all(&board, depth, &self.tt, self.board_ply, self.search.ply)
         };
 
-        let mut move_number = 1;
+        //let mut move_number = 1;
         let mut first_search = true;
         let mut max_eval = i64::MIN + 1;
         let mut best_mv = None;
         for mv in moves {
             // Send current searching move for the top level of the search.
+            /*
             if self.search.ply == 0 {
                 self.message_tx
                     .send(UciSenderMessage::CurrMoveInfo(*mv, move_number))
                     .expect("Failed to send message to UCI sender.");
                 move_number += 1;
             }
+            */
 
             let new_board = board.make_move_new(*mv);
 
@@ -262,11 +264,7 @@ impl Engine {
             self.search.ply += 1;
 
             let mut new_eval;
-            if first_search {
-                // Evaluate new position fully if first search.
-                new_eval = self.pvs(new_board, &None, -beta, -alpha, depth - 1);
-                first_search = false;
-            } else {
+            if !first_search {
                 // Perform null-window search on following searches.
                 new_eval = self.pvs(new_board, &None, -alpha - 1, -alpha, depth - 1);
 
@@ -277,6 +275,10 @@ impl Engine {
                 {
                     new_eval = self.pvs(new_board, &None, -beta, -alpha, depth - 1);
                 }
+            } else {
+                // Evaluate new position fully if first search.
+                new_eval = self.pvs(new_board, &None, -beta, -alpha, depth - 1);
+                first_search = false;
             }
 
             // Pop new position from the stack and decrement search ply.

--- a/src/engine/engine_uci.rs
+++ b/src/engine/engine_uci.rs
@@ -15,7 +15,6 @@ impl Engine {
         self.tt.clear();
         self.position_stack.clear();
         self.position_stack.push((board, true));
-        self.board_ply = 0;
         self.search = Search::default();
     }
 
@@ -50,8 +49,6 @@ impl Engine {
 
         // Set board.
         self.board = board;
-        // Set new ply. Minus one since initial position is on the stack.
-        self.board_ply = (self.position_stack.len() - 1) as u16;
     }
 
     /// Performes a received UCI go command search.
@@ -114,21 +111,14 @@ impl Engine {
         // Find best move.
         let best_move = self
             .tt
-            .get(self.board.get_hash() + self.board_ply as u64)
+            .get(self.board.get_hash())
             .expect("Failed to fetch board from TT")
             .mv;
 
         let new_board = self.board.make_move_new(best_move);
 
         // Find moves to ponder on after playing best move.
-        let ponder_moves = orderer::all(
-            &new_board,
-            0,
-            &self.tt,
-            // Plus one since a move was played above.
-            self.board_ply + 1,
-            self.search.ply,
-        );
+        let ponder_moves = orderer::all(&new_board, 0, &self.tt);
         // Give a selection of five moves to ponder on.
         let ponder_moves = ponder_moves.into_iter().take(5).collect::<Vec<ChessMove>>();
 

--- a/src/orderer/orderer.rs
+++ b/src/orderer/orderer.rs
@@ -18,14 +18,14 @@ pub fn all(board: &Board, depth: u16, tt: &TT, board_ply: u16, search_ply: u16) 
     let mut moves = MoveGen::new_legal(board);
 
     // Plus one for principal variation move.
-    let mut ret = Vec::with_capacity(moves.len() + 1);
+    let mut ret = Vec::with_capacity(moves.len());
 
     // Get all captures and order them.
     moves.set_iterator_mask(orderer_masks::captures_mask(board));
     let captures = orderer_see::see_order_captures(board, Vec::from_iter(&mut moves));
 
     moves.set_iterator_mask(!EMPTY);
-    let mut pv_hash_moves = BinaryHeap::new();
+    let mut pv_moves = BinaryHeap::new();
     let mut killer_moves = BinaryHeap::new();
     let mut bad_captures = BinaryHeap::new();
     let mut remaining_moves = Vec::new();
@@ -34,9 +34,9 @@ pub fn all(board: &Board, depth: u16, tt: &TT, board_ply: u16, search_ply: u16) 
         let hash = board.make_move_new(mv).get_hash() + board_ply as u64 + search_ply as u64;
         if let Some(entry) = tt.get(hash) {
             match entry.flag {
-                // PV hash move at higher or equal depth.
+                // PV move at higher or equal depth.
                 TtEntryFlag::Exact if entry.depth >= depth => {
-                    pv_hash_moves.push(OrdererEntry::new(entry.value(board.side_to_move()), mv))
+                    pv_moves.push(OrdererEntry::new(entry.value(board.side_to_move()), mv))
                 }
                 // Killer move at higher or equal depth.
                 TtEntryFlag::Beta if entry.depth >= depth => {
@@ -49,14 +49,8 @@ pub fn all(board: &Board, depth: u16, tt: &TT, board_ply: u16, search_ply: u16) 
         }
     }
 
-    // Search principal variation move. Will be doubly in list, second search uses the hashed
-    // result.
-    if let Some(entry) = tt.get(board.get_hash() + board_ply as u64 + search_ply as u64) {
-        ret.push(entry.mv);
-    }
-
     // Search PV hash moves.
-    ret.extend(pv_hash_moves.iter().map(|entry| entry.mv));
+    ret.extend(pv_moves.iter().map(|entry| entry.mv));
 
     // Search good and equal captures.
     for entry in captures {

--- a/src/orderer/orderer.rs
+++ b/src/orderer/orderer.rs
@@ -31,8 +31,8 @@ pub fn all(board: &Board, depth: u16, tt: &TT, board_ply: u16, search_ply: u16) 
     let mut remaining_moves = Vec::new();
 
     for mv in moves {
-        let hash = board.make_move_new(mv).get_hash() + board_ply as u64 + search_ply as u64;
-        if let Some(entry) = tt.get(hash) {
+        // Plus one since the move has been made and is one ply further down.
+        if let Some(entry) = tt.get(board.make_move_new(mv).get_hash() + board_ply as u64 + 1) {
             match entry.flag {
                 // PV move at higher or equal depth.
                 TtEntryFlag::Exact if entry.depth >= depth => {

--- a/src/orderer/orderer.rs
+++ b/src/orderer/orderer.rs
@@ -31,7 +31,7 @@ pub fn all(board: &Board, depth: u16, tt: &TT, board_ply: u16, search_ply: u16) 
     let mut remaining_moves = Vec::new();
 
     for mv in moves {
-        let hash = board.make_move_new(mv).get_hash() + board_ply as u64;
+        let hash = board.make_move_new(mv).get_hash() + board_ply as u64 + search_ply as u64;
         if let Some(entry) = tt.get(hash) {
             match entry.flag {
                 // PV move at higher or equal depth.

--- a/src/orderer/orderer.rs
+++ b/src/orderer/orderer.rs
@@ -31,7 +31,6 @@ pub fn all(board: &Board, depth: u16, tt: &TT) -> Vec<ChessMove> {
     let mut remaining_moves = Vec::new();
 
     for mv in moves {
-        // Plus one since the move has been made and is one ply further down.
         if let Some(entry) = tt.get(board.make_move_new(mv).get_hash()) {
             match entry.flag {
                 // PV move at higher or equal depth.

--- a/src/orderer/orderer.rs
+++ b/src/orderer/orderer.rs
@@ -14,7 +14,7 @@ use crate::{
 /// 4. Killer moves.
 /// 5. Bad captures.
 /// 6. Remaining moves (random order).
-pub fn all(board: &Board, depth: u16, tt: &TT, board_ply: u16, search_ply: u16) -> Vec<ChessMove> {
+pub fn all(board: &Board, depth: u16, tt: &TT) -> Vec<ChessMove> {
     let mut moves = MoveGen::new_legal(board);
 
     // Plus one for principal variation move.
@@ -32,7 +32,7 @@ pub fn all(board: &Board, depth: u16, tt: &TT, board_ply: u16, search_ply: u16) 
 
     for mv in moves {
         // Plus one since the move has been made and is one ply further down.
-        if let Some(entry) = tt.get(board.make_move_new(mv).get_hash() + board_ply as u64 + 1) {
+        if let Some(entry) = tt.get(board.make_move_new(mv).get_hash()) {
             match entry.flag {
                 // PV move at higher or equal depth.
                 TtEntryFlag::Exact if entry.depth >= depth => {
@@ -51,7 +51,7 @@ pub fn all(board: &Board, depth: u16, tt: &TT, board_ply: u16, search_ply: u16) 
 
     // Search principal variation move. Will be doubly in list, second search uses the hashed
     // result.
-    if let Some(entry) = tt.get(board.get_hash() + board_ply as u64) {
+    if let Some(entry) = tt.get(board.get_hash()) {
         ret.push(entry.mv);
     }
 

--- a/src/orderer/orderer.rs
+++ b/src/orderer/orderer.rs
@@ -31,7 +31,7 @@ pub fn all(board: &Board, depth: u16, tt: &TT, board_ply: u16, search_ply: u16) 
     let mut remaining_moves = Vec::new();
 
     for mv in moves {
-        let hash = board.make_move_new(mv).get_hash() + board_ply as u64 + search_ply as u64;
+        let hash = board.make_move_new(mv).get_hash() + board_ply as u64;
         if let Some(entry) = tt.get(hash) {
             match entry.flag {
                 // PV move at higher or equal depth.
@@ -51,7 +51,7 @@ pub fn all(board: &Board, depth: u16, tt: &TT, board_ply: u16, search_ply: u16) 
 
     // Search principal variation move. Will be doubly in list, second search uses the hashed
     // result.
-    if let Some(entry) = tt.get(board.get_hash() + board_ply as u64 + search_ply as u64) {
+    if let Some(entry) = tt.get(board.get_hash() + board_ply as u64) {
         ret.push(entry.mv);
     }
 

--- a/src/orderer/orderer.rs
+++ b/src/orderer/orderer.rs
@@ -18,7 +18,7 @@ pub fn all(board: &Board, depth: u16, tt: &TT, board_ply: u16, search_ply: u16) 
     let mut moves = MoveGen::new_legal(board);
 
     // Plus one for principal variation move.
-    let mut ret = Vec::with_capacity(moves.len());
+    let mut ret = Vec::with_capacity(moves.len() + 1);
 
     // Get all captures and order them.
     moves.set_iterator_mask(orderer_masks::captures_mask(board));
@@ -47,6 +47,12 @@ pub fn all(board: &Board, depth: u16, tt: &TT, board_ply: u16, search_ply: u16) 
         } else {
             remaining_moves.push(mv);
         }
+    }
+
+    // Search principal variation move. Will be doubly in list, second search uses the hashed
+    // result.
+    if let Some(entry) = tt.get(board.get_hash() + board_ply as u64 + search_ply as u64) {
+        ret.push(entry.mv);
     }
 
     // Search PV hash moves.

--- a/src/uci/uci_sender.rs
+++ b/src/uci/uci_sender.rs
@@ -8,8 +8,6 @@ pub enum UciSenderMessage {
     BestMove(ChessMove, Option<Vec<ChessMove>>),
     /// General info message.
     SearchInfo(u16, Duration, u64, Vec<ChessMove>, i64),
-    /// Current move specific info message.
-    CurrMoveInfo(ChessMove, u64),
 }
 
 /// Struct acting as a UCI sender. It runs in its own thread and communicates with the engine via
@@ -34,9 +32,6 @@ impl UciSender {
                 }
                 UciSenderMessage::SearchInfo(depth, time, nodes, pv, score_cp) => {
                     UciSender::search_info(depth, time, nodes, pv, score_cp)
-                }
-                UciSenderMessage::CurrMoveInfo(curr_move, curr_move_number) => {
-                    UciSender::curr_move_info(curr_move, curr_move_number)
                 }
             }
         }
@@ -70,9 +65,10 @@ impl UciSender {
 
     /// General info message.
     fn search_info(depth: u16, time: Duration, nodes: u64, pv: Vec<ChessMove>, score_cp: i64) {
-        // FIXME: seldepth, nps, refutation, currline and score mate should be sent.
+        // FIXME: seldepth, refutation, currline and score mate should be sent.
         let mut msg = format!(
-            "info depth {depth} time {} nodes {nodes} score cp {score_cp}",
+            "info depth {depth} time {} nodes {nodes} nps {} score cp {score_cp}",
+            nodes / time.as_secs(),
             time.as_millis(),
         );
 
@@ -85,10 +81,5 @@ impl UciSender {
         }
 
         println!("{msg}");
-    }
-
-    /// Current move specific info message.
-    fn curr_move_info(curr_move: ChessMove, curr_move_number: u64) {
-        println!("info currmove {curr_move} currmovenumber {curr_move_number}");
     }
 }

--- a/src/uci/uci_sender.rs
+++ b/src/uci/uci_sender.rs
@@ -68,7 +68,7 @@ impl UciSender {
         // FIXME: seldepth, refutation, currline and score mate should be sent.
         let mut msg = format!(
             "info depth {depth} time {} nodes {nodes} nps {} score cp {score_cp}",
-            nodes / time.as_secs(),
+            nodes / time.as_secs().max(1),
             time.as_millis(),
         );
 

--- a/src/uci/uci_sender.rs
+++ b/src/uci/uci_sender.rs
@@ -44,7 +44,7 @@ impl UciSender {
 
     /// id.
     pub fn id() {
-        println!("id name Rxh7+ V1.1");
+        println!("id name Rxh7+ V1.2");
         println!("id author ComicalCache");
         println!("uciok");
     }

--- a/src/uci/uci_sender.rs
+++ b/src/uci/uci_sender.rs
@@ -68,8 +68,8 @@ impl UciSender {
         // FIXME: seldepth, refutation, currline and score mate should be sent.
         let mut msg = format!(
             "info depth {depth} time {} nodes {nodes} nps {} score cp {score_cp}",
-            nodes / time.as_secs().max(1),
             time.as_millis(),
+            nodes / time.as_secs().max(1),
         );
 
         if !pv.is_empty() {


### PR DESCRIPTION
In the benchmark it lead to a more balanced play, winning more evenly on both sides but performed worse against V1.1.0.
This change reduces search time and prunes more which is why I will take it even if it performs slightly worse at the time.

```
Elo difference: -9.4 +/- 16.1, LOS: 12.8 %, DrawRatio: 43.7 %
SPRT: llr -2.12 (-71.9%), lbound -2.94, ubound 2.94

Player: Rxh7p V1.2.0
   "Draw by 3-fold repetition": 391
   "Draw by fifty moves rule": 19
   "Draw by insufficient mating material": 27
   "Loss: Black loses on time": 1
   "Loss: Black mates": 114
   "Loss: White mates": 180
   "Win: Black mates": 131
   "Win: White mates": 137
Player: Rxh7p V1.1.0
   "Draw by 3-fold repetition": 391
   "Draw by fifty moves rule": 19
   "Draw by insufficient mating material": 27
   "Loss: Black mates": 131
   "Loss: White mates": 137
   "Win: Black loses on time": 1
   "Win: Black mates": 114
   "Win: White mates": 180
```