### PR TITLE
Fix repetition bug and reduce positions stack size

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Benchmarking can be done using cutechess-cli.
 
 ```sh
 cutechess-cli
-  -engine name=new proto=uci cmd=new -engine name=old proto=uci cmd=old -openings file=openings order=random policy=round plies=14 -concurrency 8 -ratinginterval 2 -rounds 500 -games 2 -maxmoves 120 -each st=1 ponder -sprt elo0=0 elo1=10 alpha=0.05 beta=0.05
+  -engine name=new proto=uci cmd=new -engine name=old proto=uci cmd=old -openings file=openings order=random policy=round plies=14 -concurrency 8 -ratinginterval 2 -rounds 500 -games 2 -maxmoves 120 -each tc=30+0.5 ponder -sprt elo0=0 elo1=10 alpha=0.05 beta=0.05
 ```
 
 Explaination:
@@ -22,7 +22,7 @@ Explaination:
 - `-games 2`: play for 500 rounds each two games.
 - `-maxmoves 120`: if the game has not ended after 120 moves (240 plies) consider it drawn
 - `-each`: apply the following settings to both engines.
-- `st=1`: think one second per move.
+- `tc=30+0.5`: play 30s with .5s increments.
 - `ponder`: allow engines to ponder during opponent moves.
 - `sprt elo0=0 elo1=150 alpha=0.05 beta=0.05`: sequential probability ratio test. Hypthoesis H1 is that engine A is stronger than engine B by at least elo0, hypthesis H0 is that engine A is not stronger than B by at least elo1. If either H0 or H1 are fulfilled with error in alpha and beta the match is stopped.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Benchmarking can be done using cutechess-cli.
 
 ```sh
 cutechess-cli
-  -engine name=new proto=uci cmd=new -engine name=old proto=uci cmd=old -openings file=openings order=random policy=round plies=14 -concurrency 8 -ratinginterval 2 -rounds 500 -games 2 -each tc=30+0.5 ponder -sprt elo0=0 elo1=10 alpha=0.05 beta=0.05
+  -engine name=new proto=uci cmd=new -engine name=old proto=uci cmd=old -openings file=openings order=random policy=round plies=14 -concurrency 8 -ratinginterval 2 -rounds 500 -games 2 -maxmoves 120 -each tc=30+0.5 ponder -sprt elo0=0 elo1=10 alpha=0.05 beta=0.05
 ```
 
 Explaination:
@@ -20,6 +20,7 @@ Explaination:
 - `-ratinginterval 2`: print the rating every two finished games.
 - `-rounds 500`: play for 500 rounds each two games.
 - `-games 2`: play for 500 rounds each two games.
+- `-maxmoves 120`: if the game has not ended after 120 moves (240 plies) consider it drawn
 - `-each`: apply the following settings to both engines.
 - `tc=30+0.5`: play 30+0.5s.
 - `ponder`: allow engines to ponder during opponent moves.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Benchmarking can be done using cutechess-cli.
 
 ```sh
 cutechess-cli
-  -engine name=new proto=uci cmd=new -engine name=old proto=uci cmd=old -openings file=openings order=random policy=round plies=14 -concurrency 8 -ratinginterval 2 -rounds 500 -games 2 -maxmoves 120 -each tc=15+0.5 ponder -sprt elo0=0 elo1=10 alpha=0.05 beta=0.05
+  -engine name=new proto=uci cmd=new -engine name=old proto=uci cmd=old -openings file=openings order=random policy=round plies=14 -concurrency 8 -ratinginterval 2 -rounds 500 -games 2 -maxmoves 120 -each st=1 ponder -sprt elo0=0 elo1=10 alpha=0.05 beta=0.05
 ```
 
 Explaination:
@@ -22,7 +22,7 @@ Explaination:
 - `-games 2`: play for 500 rounds each two games.
 - `-maxmoves 120`: if the game has not ended after 120 moves (240 plies) consider it drawn
 - `-each`: apply the following settings to both engines.
-- `tc=15+0.5`: play 15+0.5s.
+- `st=1`: think one second per move.
 - `ponder`: allow engines to ponder during opponent moves.
 - `sprt elo0=0 elo1=150 alpha=0.05 beta=0.05`: sequential probability ratio test. Hypthoesis H1 is that engine A is stronger than engine B by at least elo0, hypthesis H0 is that engine A is not stronger than B by at least elo1. If either H0 or H1 are fulfilled with error in alpha and beta the match is stopped.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Benchmarking can be done using cutechess-cli.
 
 ```sh
 cutechess-cli
-  -engine name=new proto=uci cmd=new -engine name=old proto=uci cmd=old -openings file=openings order=random policy=round plies=14 -concurrency 8 -ratinginterval 2 -rounds 500 -games 2 -maxmoves 120 -each tc=30+0.5 ponder -sprt elo0=0 elo1=10 alpha=0.05 beta=0.05
+  -engine name=new proto=uci cmd=new -engine name=old proto=uci cmd=old -openings file=openings order=random policy=round plies=14 -concurrency 8 -ratinginterval 2 -rounds 500 -games 2 -maxmoves 120 -each tc=15+0.5 ponder -sprt elo0=0 elo1=10 alpha=0.05 beta=0.05
 ```
 
 Explaination:
@@ -22,7 +22,7 @@ Explaination:
 - `-games 2`: play for 500 rounds each two games.
 - `-maxmoves 120`: if the game has not ended after 120 moves (240 plies) consider it drawn
 - `-each`: apply the following settings to both engines.
-- `tc=30+0.5`: play 30+0.5s.
+- `tc=15+0.5`: play 15+0.5s.
 - `ponder`: allow engines to ponder during opponent moves.
 - `sprt elo0=0 elo1=150 alpha=0.05 beta=0.05`: sequential probability ratio test. Hypthoesis H1 is that engine A is stronger than engine B by at least elo0, hypthesis H0 is that engine A is not stronger than B by at least elo1. If either H0 or H1 are fulfilled with error in alpha and beta the match is stopped.
 

--- a/positions.txt
+++ b/positions.txt
@@ -7,5 +7,8 @@ Threefold repetition:
 Forced threefold to not lose for white:
 6k1/4Q3/p5p1/8/8/6P1/P4PKP/1rq5 w - - 4 21
 
+Weird threefold:
+position fen rnb1kb1r/pppp1ppp/5n2/2qNN3/3PP3/8/PPP2PPP/R1BQKB1R b KQkq - 0 6 moves c5d6 e5c4 d6c6 c4e5 c6d6 e5c4 d6c6
+
 Endgames:
 8/k7/3p4/p2P1p2/P2P1P2/8/8/K7 w - - 0 1

--- a/positions.txt
+++ b/positions.txt
@@ -4,5 +4,8 @@ White advantage:
 Threefold repetition:
 8/r3bp2/4k1p1/P7/P2QP2P/3P1P1P/5R2/4B1K1 w - - 6 35
 
+Forced threefold to not lose for white:
+6k1/4Q3/p5p1/8/8/6P1/P4PKP/1rq5 w - - 4 21
+
 Endgames:
 8/k7/3p4/p2P1p2/P2P1P2/8/8/K7 w - - 0 1

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -15,13 +15,15 @@ use crate::{
 
 /// The chess engine itself, it performs the search and data keeping.
 pub struct Engine {
+    /// Initial position.
+    pub(super) initial_board: u64,
     /// Internal board.
     pub(super) board: Board,
     /// Transposition table.
     pub(super) tt: TT,
 
     /// Stack of played positions to detect threefold repetitions.
-    pub(super) position_stack: Vec<(Board, bool)>,
+    pub(super) position_stack: Vec<(u64, bool)>,
 
     // TODO: 50 move rule.
     /// Information about the current search.
@@ -45,9 +47,10 @@ impl Engine {
         let board = Board::default();
 
         Engine {
+            initial_board: board.get_hash(),
             board,
             tt: TT::new(),
-            position_stack: vec![(board, true)],
+            position_stack: vec![(board.get_hash(), true)],
             search: Search::default(),
             message_tx,
             stop_rx,
@@ -150,14 +153,14 @@ impl Engine {
 
         // Depth limit.
         if let Some(depth) = self.search.depth
-            && self.search.ply >= depth
+            && self.search.ply > depth
         {
             return true;
         }
 
         // Node limit.
         if let Some(nodes) = self.search.node_limit
-            && self.search.nodes >= nodes
+            && self.search.nodes > nodes
         {
             return true;
         }
@@ -237,13 +240,9 @@ impl Engine {
             let new_board = board.make_move_new(*mv);
 
             // Add new position to and increment search ply.
-            // Save to unwrap since always at least one position exists after initialization.
-            let irreversible = Engine::move_is_irreversible(
-                &self.position_stack.last().unwrap().0,
-                &new_board,
-                *mv,
-            );
-            self.position_stack.push((new_board, irreversible));
+            let irreversible = Engine::move_is_irreversible(&board, &new_board, *mv);
+            self.position_stack
+                .push((new_board.get_hash(), irreversible));
             self.search.ply += 1;
 
             let mut new_eval;
@@ -252,10 +251,9 @@ impl Engine {
                 new_eval = self.pvs(new_board, &None, -alpha - 1, -alpha, depth - 1);
 
                 // If the null-window search failed high, repeat with a full search.
-                // Inverse result due to symmetry.
                 if let Some(eval) = new_eval
                 // Prune non-PV moves. In rare cases this condition is true for PV moves, but the
-                // chance is negligible.
+                // chance is negligible. Inverse result due to symmetry.
                     && -eval > alpha
                     && -eval < beta
                 {

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -73,6 +73,11 @@ impl Engine {
         let mut eval = 0;
 
         for depth in 1.. {
+            // Search at most to depth 30.
+            if depth > 30 {
+                break;
+            }
+
             // i64::MIN + 1 to avoid overflow when negating the value.
             let new_eval = self.pvs(self.board, &searchmoves, i64::MIN + 1, i64::MAX, depth);
 
@@ -113,7 +118,7 @@ impl Engine {
     /// Returns the current principal variation of the internal state.
     fn pv(&self, depth: u16) -> Vec<ChessMove> {
         // At most print pv of ten plies.
-        let depth = depth.max(10);
+        let depth = depth.min(10);
         let mut pv = Vec::with_capacity(depth as usize);
         let mut temp_board = self.board;
 
@@ -167,11 +172,6 @@ impl Engine {
         if let Some(depth) = self.search.depth
             && self.search.ply > depth
         {
-            return true;
-        }
-
-        // Never search past depth 30.
-        if self.search.ply > 30 {
             return true;
         }
 

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -10,7 +10,7 @@ use crate::{
     engine::search::Search,
     evaluator, orderer,
     tt::{TT, TtEntry, TtEntryFlag},
-    uci::UciSenderMessage,
+    uci::{UciSender, UciSenderMessage},
 };
 
 /// The chess engine itself, it performs the search and data keeping.
@@ -96,6 +96,15 @@ impl Engine {
                     .duration_since(self.search.start_time)
                     .unwrap();
 
+                UciSender::search_info(
+                    depth,
+                    search_time,
+                    self.search.nodes,
+                    // FIXME: gather pv should not be done here on the hot path?
+                    self.pv(pv_depth),
+                    eval,
+                );
+                /*
                 self.message_tx
                     .send(UciSenderMessage::SearchInfo(
                         depth,
@@ -106,6 +115,7 @@ impl Engine {
                         eval,
                     ))
                     .expect("Failed to send message to UCI sender.");
+                */
             }
 
             // Search was cancelled.

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -1,8 +1,4 @@
-use std::{
-    cmp::max,
-    sync::mpsc::{Receiver, Sender},
-    time::SystemTime,
-};
+use std::{cmp::max, sync::mpsc::Receiver, time::SystemTime};
 
 use chess::{Board, BoardStatus, ChessMove};
 
@@ -10,7 +6,7 @@ use crate::{
     engine::search::Search,
     evaluator, orderer,
     tt::{TT, TtEntry, TtEntryFlag},
-    uci::{UciSender, UciSenderMessage},
+    uci::uci_sender,
 };
 
 /// The chess engine itself, it performs the search and data keeping.
@@ -29,8 +25,6 @@ pub struct Engine {
     /// Information about the current search.
     pub(super) search: Search,
 
-    /// UCI sender. Sends messages to UCI on our behalf to avoid exepnsive stdio on hot path.
-    pub(super) message_tx: Sender<UciSenderMessage>,
     /// Stop receiver. Receives if a stop command was sent.
     pub(super) stop_rx: Receiver<()>,
     /// Ponder receiver. Receives if a ponderhit command was sent.
@@ -39,11 +33,7 @@ pub struct Engine {
 
 impl Engine {
     /// Creates a new engine.
-    pub fn new(
-        message_tx: Sender<UciSenderMessage>,
-        stop_rx: Receiver<()>,
-        ponderhit_rx: Receiver<()>,
-    ) -> Self {
+    pub fn new(stop_rx: Receiver<()>, ponderhit_rx: Receiver<()>) -> Self {
         let board = Board::default();
 
         Engine {
@@ -52,7 +42,6 @@ impl Engine {
             tt: TT::new(),
             position_stack: vec![(board.get_hash(), true)],
             search: Search::default(),
-            message_tx,
             stop_rx,
             ponderhit_rx,
         }
@@ -96,7 +85,7 @@ impl Engine {
                     .duration_since(self.search.start_time)
                     .unwrap();
 
-                UciSender::search_info(
+                uci_sender::search_info(
                     depth,
                     search_time,
                     self.search.nodes,
@@ -104,18 +93,6 @@ impl Engine {
                     self.pv(pv_depth),
                     eval,
                 );
-                /*
-                self.message_tx
-                    .send(UciSenderMessage::SearchInfo(
-                        depth,
-                        search_time,
-                        self.search.nodes,
-                        // FIXME: gather pv should not be done here on the hot path?
-                        self.pv(pv_depth),
-                        eval,
-                    ))
-                    .expect("Failed to send message to UCI sender.");
-                */
             }
 
             // Search was cancelled.

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -203,7 +203,7 @@ impl Engine {
 
         // Quiescence search to avoid event horizon.
         if depth == 0 {
-            return Some(Engine::quiescence(board, alpha, beta));
+            return self.quiescence(board, alpha, beta);
         }
 
         // Checkmate or stalemate.
@@ -310,29 +310,39 @@ impl Engine {
     }
 
     /// Performs a quiescence search on a given board.
-    fn quiescence(board: Board, mut alpha: i64, beta: i64) -> i64 {
+    fn quiescence(&mut self, board: Board, mut alpha: i64, beta: i64) -> Option<i64> {
+        if self.stop_search() {
+            return None;
+        }
+
         let mut max_eval = evaluator::evaluate(&board);
 
         // Cut-off, move was too good, opponent would not allow it.
         if max_eval >= beta {
-            return max_eval;
+            return Some(max_eval);
         }
 
         alpha = max(max_eval, alpha);
 
         for capture in orderer::quiescence(&board) {
             // Evaluate new position.
-            let new_eval = -Engine::quiescence(board.make_move_new(capture), -beta, -alpha);
+            if let Some(new_eval) = self.quiescence(board.make_move_new(capture), -beta, -alpha) {
+                // Invert result due to symmetry.
+                let new_eval = -new_eval;
 
-            max_eval = max(new_eval, max_eval);
-            alpha = max(new_eval, alpha);
+                max_eval = max(new_eval, max_eval);
+                alpha = max(new_eval, alpha);
 
-            // Cut-off, move was too good, opponent would not allow it.
-            if new_eval >= beta {
-                break;
+                // Cut-off, move was too good, opponent would not allow it.
+                if new_eval >= beta {
+                    break;
+                }
+            } else {
+                // If quiescence returns None, search was cancelled, return up the chain.
+                return None;
             }
         }
 
-        max_eval
+        Some(max_eval)
     }
 }

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -249,6 +249,8 @@ impl Engine {
             let mut new_eval;
             if !first_search {
                 // Gather moves here and pass down to avoid having to search moves twice.
+                // This means second search doesn't profit from results of first in terms of
+                // ordering but SEE during ordering is very expensive.
                 let new_moves = Some(orderer::all(&new_board, depth, &self.tt));
 
                 // Perform null-window search on following searches.

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -248,8 +248,11 @@ impl Engine {
 
             let mut new_eval;
             if !first_search {
+                // Gather moves here and pass down to avoid having to search moves twice.
+                let new_moves = Some(orderer::all(&new_board, depth, &self.tt));
+
                 // Perform null-window search on following searches.
-                new_eval = self.pvs(new_board, &None, -alpha - 1, -alpha, depth - 1);
+                new_eval = self.pvs(new_board, &new_moves, -alpha - 1, -alpha, depth - 1);
 
                 // If the null-window search failed high, repeat with a full search.
                 if let Some(eval) = new_eval
@@ -258,7 +261,7 @@ impl Engine {
                     && -eval > alpha
                     && -eval < beta
                 {
-                    new_eval = self.pvs(new_board, &None, -beta, -alpha, depth - 1);
+                    new_eval = self.pvs(new_board, &new_moves, -beta, -alpha, depth - 1);
                 }
             } else {
                 // Evaluate new position fully if first search.

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -153,6 +153,16 @@ impl Engine {
             return false;
         }
 
+        // Move time limit.
+        if let Some(move_time) = self.search.move_time
+            && SystemTime::now()
+                .duration_since(self.search.start_time)
+                .unwrap()
+                > move_time
+        {
+            return true;
+        }
+
         // Depth limit.
         if let Some(depth) = self.search.depth
             && self.search.ply > depth
@@ -160,19 +170,14 @@ impl Engine {
             return true;
         }
 
-        // Node limit.
-        if let Some(nodes) = self.search.node_limit
-            && self.search.nodes > nodes
-        {
+        // Never search past depth 30.
+        if self.search.ply > 30 {
             return true;
         }
 
-        // Move time limit.
-        if let Some(move_time) = self.search.move_time
-            && SystemTime::now()
-                .duration_since(self.search.start_time)
-                .unwrap()
-                > move_time
+        // Node limit.
+        if let Some(nodes) = self.search.node_limit
+            && self.search.nodes > nodes
         {
             return true;
         }

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -194,8 +194,8 @@ impl Engine {
         // Count node as visited.
         self.search.nodes += 1;
 
-        // Return score of 0 if position is a three-fold repetition.
-        if self.threefold_repetition() {
+        // Return score of 0 if position is a repetition.
+        if self.repetition() {
             return Some(0);
         }
 
@@ -210,11 +210,10 @@ impl Engine {
         }
 
         let prev_alpha = alpha;
-        let hash = board.get_hash();
         let side = board.side_to_move();
 
         // If viable entry exists return evaluation.
-        if let Some(entry) = self.tt.get(hash)
+        if let Some(entry) = self.tt.get(board.get_hash())
             && entry.depth >= depth
         {
             let eval = entry.value(side);
@@ -303,7 +302,7 @@ impl Engine {
             side,
             max_eval,
         );
-        self.tt.set(hash, tt_entry);
+        self.tt.set(board.get_hash(), tt_entry);
 
         Some(max_eval)
     }

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -62,8 +62,8 @@ impl Engine {
         let mut eval = 0;
 
         for depth in 1.. {
-            // Search at most to depth 30.
-            if depth > 30 {
+            // Search at most to depth 35.
+            if depth > 35 {
                 break;
             }
 
@@ -104,8 +104,8 @@ impl Engine {
 
     /// Returns the current principal variation of the internal state.
     fn pv(&self, depth: u16) -> Vec<ChessMove> {
-        // At most print pv of ten plies.
-        let depth = depth.min(10);
+        // At most print pv of eight plies.
+        let depth = depth.min(8);
         let mut pv = Vec::with_capacity(depth as usize);
         let mut temp_board = self.board;
 

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -112,6 +112,7 @@ impl Engine {
 
     /// Returns the current principal variation of the internal state.
     fn pv(&self, depth: u16) -> Vec<ChessMove> {
+        // At most print pv of ten plies.
         let depth = depth.max(10);
         let mut pv = Vec::with_capacity(depth as usize);
         let mut temp_board = self.board;

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -112,6 +112,7 @@ impl Engine {
 
     /// Returns the current principal variation of the internal state.
     fn pv(&self, depth: u16) -> Vec<ChessMove> {
+        let depth = depth.max(10);
         let mut pv = Vec::with_capacity(depth as usize);
         let mut temp_board = self.board;
 

--- a/src/engine/engine_repetition.rs
+++ b/src/engine/engine_repetition.rs
@@ -11,7 +11,7 @@ impl Engine {
         }
 
         // Save to unwrap since at least eight moves have been played.
-        let target_hash = self.position_stack.last().unwrap().0.get_hash();
+        let target_hash = self.position_stack.last().unwrap().0;
         let mut repetitions = 1;
 
         let len = self.position_stack.len();
@@ -22,7 +22,7 @@ impl Engine {
             }
 
             // Check if it is a repetition.
-            if self.position_stack[idx].0.get_hash() == target_hash {
+            if self.position_stack[idx].0 == target_hash {
                 repetitions += 1;
 
                 if repetitions == 3 {

--- a/src/engine/engine_repetition.rs
+++ b/src/engine/engine_repetition.rs
@@ -3,19 +3,12 @@ use chess::{Board, ChessMove, Color, Piece};
 use crate::engine::Engine;
 
 impl Engine {
-    /// Checks if the current position is a threefold repetition.
-    pub(super) fn threefold_repetition(&self) -> bool {
-        // Can't be a three fold repetition if not sufficient moves have been played.
-        if self.position_stack.len() < 8 {
-            return false;
-        }
-
-        // Save to unwrap since at least eight moves have been played.
+    /// Checks if the current position is a repetition.
+    pub(super) fn repetition(&self) -> bool {
+        // Save to unwrap since at least the start pos exists.
         let target_hash = self.position_stack.last().unwrap().0;
-        let mut repetitions = 1;
 
-        let len = self.position_stack.len();
-        for idx in (0..len - 1).rev() {
+        for idx in (0..self.position_stack.len() - 1).rev() {
             // Don't search past irreversible moves.
             if self.position_stack[idx].1 {
                 break;
@@ -23,11 +16,7 @@ impl Engine {
 
             // Check if it is a repetition.
             if self.position_stack[idx].0 == target_hash {
-                repetitions += 1;
-
-                if repetitions == 3 {
-                    return true;
-                }
+                return true;
             }
         }
 

--- a/src/engine/engine_uci.rs
+++ b/src/engine/engine_uci.rs
@@ -11,18 +11,18 @@ use crate::{
 impl Engine {
     /// Initializes the engine with defaults.
     pub fn init(&mut self, board: Board) {
+        self.initial_board = board.get_hash();
         self.board = board;
         self.tt.clear();
         self.position_stack.clear();
-        self.position_stack.push((board, true));
+        self.position_stack.push((board.get_hash(), true));
         self.search = Search::default();
     }
 
     /// Handles a received UCI position command and initializes itself accordingly.
     pub fn uci_position(&mut self, mut board: Board, moves: Option<Vec<ChessMove>>) {
         // Initial position does not match engine.
-        // Safe to unwrap since always one board exists (default by default...).
-        if board.get_hash() != self.position_stack.first().unwrap().0.get_hash() {
+        if board.get_hash() != self.initial_board {
             self.init(board);
         }
 
@@ -42,7 +42,8 @@ impl Engine {
             let new_board = board.make_move_new(mv);
 
             let irreversible = Engine::move_is_irreversible(&board, &new_board, mv);
-            self.position_stack.push((new_board, irreversible));
+            self.position_stack
+                .push((new_board.get_hash(), irreversible));
 
             board = new_board;
         }

--- a/src/engine/engine_uci.rs
+++ b/src/engine/engine_uci.rs
@@ -76,15 +76,15 @@ impl Engine {
             Color::White => {
                 if let Some(time) = config.wtime {
                     let inc = config.winc.unwrap_or(Duration::ZERO);
-                    // Just divide remaining time by 25.
-                    self.search.move_time = Some((time + inc).div_f64(25.));
+                    // Just divide remaining time by 30.
+                    self.search.move_time = Some((time + inc).div_f64(30.));
                 }
             }
             Color::Black => {
                 if let Some(time) = config.btime {
                     let inc = config.binc.unwrap_or(Duration::ZERO);
-                    // Just divide remaining time by 25.
-                    self.search.move_time = Some((time + inc).div_f64(25.));
+                    // Just divide remaining time by 30.
+                    self.search.move_time = Some((time + inc).div_f64(30.));
                 }
             }
         }

--- a/src/engine/engine_uci.rs
+++ b/src/engine/engine_uci.rs
@@ -101,13 +101,13 @@ impl Engine {
             }
         }
 
-        // Subtract 100ms from the time limit to avoid losing by time.
+        /*// Subtract 100ms from the time limit to avoid losing by time.
         if let Some(time) = self.search.move_time {
             let ms = Duration::from_millis(100);
             if time > ms {
                 self.search.move_time = Some(time - ms);
             }
-        }
+        }*/
 
         // Set remaining parameters.
         self.search.node_limit = config.nodes;

--- a/src/engine/engine_uci.rs
+++ b/src/engine/engine_uci.rs
@@ -101,13 +101,13 @@ impl Engine {
             }
         }
 
-        /*// Subtract 100ms from the time limit to avoid losing by time.
+        // Subtract 20ms from the time limit to avoid losing by time.
         if let Some(time) = self.search.move_time {
-            let ms = Duration::from_millis(100);
+            let ms = Duration::from_millis(20);
             if time > ms {
                 self.search.move_time = Some(time - ms);
             }
-        }*/
+        }
 
         // Set remaining parameters.
         self.search.node_limit = config.nodes;

--- a/src/engine/engine_uci.rs
+++ b/src/engine/engine_uci.rs
@@ -101,11 +101,11 @@ impl Engine {
             }
         }
 
-        // Subtract 10ms from the time limit to avoid losing by time.
+        // Subtract 25ms from the time limit to avoid losing by time.
         if let Some(time) = self.search.move_time {
-            let ten_ms = Duration::from_millis(10);
-            if time > ten_ms {
-                self.search.move_time = Some(time - ten_ms);
+            let ms = Duration::from_millis(25);
+            if time > ms {
+                self.search.move_time = Some(time - ms);
             }
         }
 

--- a/src/engine/engine_uci.rs
+++ b/src/engine/engine_uci.rs
@@ -76,15 +76,15 @@ impl Engine {
             Color::White => {
                 if let Some(time) = config.wtime {
                     let inc = config.winc.unwrap_or(Duration::ZERO);
-                    // Just divide remaining time by 30.
-                    self.search.move_time = Some((time + inc).div_f64(30.));
+                    // Just divide remaining time by 30 plus half of the increment.
+                    self.search.move_time = Some((time + inc.div_f64(2.)).div_f64(30.));
                 }
             }
             Color::Black => {
                 if let Some(time) = config.btime {
                     let inc = config.binc.unwrap_or(Duration::ZERO);
-                    // Just divide remaining time by 30.
-                    self.search.move_time = Some((time + inc).div_f64(30.));
+                    // Just divide remaining time by 30 plus half of the increment.
+                    self.search.move_time = Some((time + inc.div_f64(2.)).div_f64(30.));
                 }
             }
         }

--- a/src/engine/engine_uci.rs
+++ b/src/engine/engine_uci.rs
@@ -101,9 +101,9 @@ impl Engine {
             }
         }
 
-        // Subtract 20ms from the time limit to avoid losing by time.
+        // Subtract 50ms from the time limit to avoid losing by time.
         if let Some(time) = self.search.move_time {
-            let ms = Duration::from_millis(20);
+            let ms = Duration::from_millis(50);
             if time > ms {
                 self.search.move_time = Some(time - ms);
             }

--- a/src/engine/engine_uci.rs
+++ b/src/engine/engine_uci.rs
@@ -101,9 +101,9 @@ impl Engine {
             }
         }
 
-        // Subtract 25ms from the time limit to avoid losing by time.
+        // Subtract 100ms from the time limit to avoid losing by time.
         if let Some(time) = self.search.move_time {
-            let ms = Duration::from_millis(25);
+            let ms = Duration::from_millis(100);
             if time > ms {
                 self.search.move_time = Some(time - ms);
             }

--- a/src/engine/engine_uci.rs
+++ b/src/engine/engine_uci.rs
@@ -101,10 +101,11 @@ impl Engine {
             }
         }
 
-        // Subtract 15ms from the time limit to avoid losing by time.
+        // Subtract 10ms from the time limit to avoid losing by time.
         if let Some(time) = self.search.move_time {
-            if time > Duration::from_millis(15) {
-                self.search.move_time = Some(time - Duration::from_millis(15));
+            let ten_ms = Duration::from_millis(10);
+            if time > ten_ms {
+                self.search.move_time = Some(time - ten_ms);
             }
         }
 

--- a/src/engine/engine_uci.rs
+++ b/src/engine/engine_uci.rs
@@ -101,9 +101,9 @@ impl Engine {
             }
         }
 
-        // Subtract 250ms from the time limit to avoid losing by time.
+        // Subtract 10ms from the time limit to avoid losing by time.
         if let Some(time) = self.search.move_time {
-            let ms = Duration::from_millis(250);
+            let ms = Duration::from_millis(10);
             if time > ms {
                 self.search.move_time = Some(time - ms);
             }

--- a/src/engine/engine_uci.rs
+++ b/src/engine/engine_uci.rs
@@ -5,7 +5,7 @@ use chess::{Board, ChessMove, Color};
 use crate::{
     engine::{Engine, search::Search},
     orderer,
-    uci::{GoCommandConfig, UciSenderMessage},
+    uci::{GoCommandConfig, UciSender, UciSenderMessage},
 };
 
 impl Engine {
@@ -132,6 +132,15 @@ impl Engine {
         let ponder_moves = ponder_moves.into_iter().take(5).collect::<Vec<ChessMove>>();
 
         // Send reply over UCI.
+        UciSender::best_move(
+            best_move,
+            if !ponder_moves.is_empty() {
+                Some(ponder_moves)
+            } else {
+                None
+            },
+        );
+        /*
         self.message_tx
             .send(UciSenderMessage::BestMove(
                 best_move,
@@ -142,5 +151,6 @@ impl Engine {
                 },
             ))
             .expect("Failed to send message to UCI sender.");
+        */
     }
 }

--- a/src/engine/engine_uci.rs
+++ b/src/engine/engine_uci.rs
@@ -5,7 +5,7 @@ use chess::{Board, ChessMove, Color};
 use crate::{
     engine::{Engine, search::Search},
     orderer,
-    uci::{GoCommandConfig, UciSender, UciSenderMessage},
+    uci::{GoCommandConfig, uci_sender},
 };
 
 impl Engine {
@@ -132,7 +132,7 @@ impl Engine {
         let ponder_moves = ponder_moves.into_iter().take(5).collect::<Vec<ChessMove>>();
 
         // Send reply over UCI.
-        UciSender::best_move(
+        uci_sender::best_move(
             best_move,
             if !ponder_moves.is_empty() {
                 Some(ponder_moves)
@@ -140,17 +140,5 @@ impl Engine {
                 None
             },
         );
-        /*
-        self.message_tx
-            .send(UciSenderMessage::BestMove(
-                best_move,
-                if !ponder_moves.is_empty() {
-                    Some(ponder_moves)
-                } else {
-                    None
-                },
-            ))
-            .expect("Failed to send message to UCI sender.");
-        */
     }
 }

--- a/src/engine/engine_uci.rs
+++ b/src/engine/engine_uci.rs
@@ -77,14 +77,14 @@ impl Engine {
                 if let Some(time) = config.wtime {
                     let inc = config.winc.unwrap_or(Duration::ZERO);
                     // Just divide remaining time by 30 plus half of the increment.
-                    self.search.move_time = Some((time + inc.div_f64(2.)).div_f64(30.));
+                    self.search.move_time = Some((time + (inc / 2)) / 30);
                 }
             }
             Color::Black => {
                 if let Some(time) = config.btime {
                     let inc = config.binc.unwrap_or(Duration::ZERO);
                     // Just divide remaining time by 30 plus half of the increment.
-                    self.search.move_time = Some((time + inc.div_f64(2.)).div_f64(30.));
+                    self.search.move_time = Some((time + (inc / 2)) / 30);
                 }
             }
         }
@@ -132,13 +132,10 @@ impl Engine {
         let ponder_moves = ponder_moves.into_iter().take(5).collect::<Vec<ChessMove>>();
 
         // Send reply over UCI.
-        uci_sender::best_move(
-            best_move,
-            if !ponder_moves.is_empty() {
-                Some(ponder_moves)
-            } else {
-                None
-            },
-        );
+        if !ponder_moves.is_empty() {
+            uci_sender::best_move(best_move, Some(ponder_moves));
+        } else {
+            uci_sender::best_move(best_move, None);
+        }
     }
 }

--- a/src/engine/engine_uci.rs
+++ b/src/engine/engine_uci.rs
@@ -101,6 +101,13 @@ impl Engine {
             }
         }
 
+        // Subtract 15ms from the time limit to avoid losing by time.
+        if let Some(time) = self.search.move_time {
+            if time > Duration::from_millis(15) {
+                self.search.move_time = Some(time - Duration::from_millis(15));
+            }
+        }
+
         // Set remaining parameters.
         self.search.node_limit = config.nodes;
         self.search.depth = config.depth;

--- a/src/engine/engine_uci.rs
+++ b/src/engine/engine_uci.rs
@@ -101,9 +101,9 @@ impl Engine {
             }
         }
 
-        // Subtract 50ms from the time limit to avoid losing by time.
+        // Subtract 250ms from the time limit to avoid losing by time.
         if let Some(time) = self.search.move_time {
-            let ms = Duration::from_millis(50);
+            let ms = Duration::from_millis(250);
             if time > ms {
                 self.search.move_time = Some(time - ms);
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use chess::Board;
 
 use crate::{
     engine::Engine,
-    uci::{UciCommand, UciReceiver, UciSender, UciSenderMessage},
+    uci::{UciCommand, UciReceiver, uci_sender},
 };
 
 mod engine;
@@ -19,14 +19,10 @@ fn main() {
     let (uci_receiver_tx, uci_receivre_rx) = mpsc::channel::<UciCommand>();
     let (stop_tx, stop_rx) = mpsc::channel::<()>();
     let (ponderhit_tx, ponderhit_rx) = mpsc::channel::<()>();
-    let (uci_sender_tx, uci_sender_rx) = mpsc::channel::<UciSenderMessage>();
-    let mut engine = Engine::new(uci_sender_tx, stop_rx, ponderhit_rx);
+    let mut engine = Engine::new(stop_rx, ponderhit_rx);
 
     let uci_receiver_thread = thread::spawn(|| {
         UciReceiver::new(uci_receiver_tx, stop_tx, ponderhit_tx).start();
-    });
-    let uci_sender_thread = thread::spawn(|| {
-        UciSender::new(uci_sender_rx).start();
     });
 
     while let Ok(command) = uci_receivre_rx.recv() {
@@ -35,7 +31,7 @@ fn main() {
             UciCommand::Invalid => unreachable!("Received unreachable command"),
             // Simple handshake by the receiver.
             UciCommand::Uci => unreachable!("Received uci command"),
-            UciCommand::IsReady => UciSender::ready_ok(),
+            UciCommand::IsReady => uci_sender::ready_ok(),
             UciCommand::UciNewGame => engine.init(Board::default()),
             UciCommand::Position(board, moves) => engine.uci_position(board, moves),
             UciCommand::Go(config) => engine.go(config),
@@ -57,8 +53,4 @@ fn main() {
     // This drops the uci sender tx and thus stops the loop in UciSender::start, causing the thread
     // to stop.
     drop(engine);
-
-    if let Err(err) = uci_sender_thread.join() {
-        println!("Failed to join uci sender thread: {err:#?}");
-    }
 }

--- a/src/uci/mod.rs
+++ b/src/uci/mod.rs
@@ -4,5 +4,4 @@ pub use uci_command::{GoCommandConfig, UciCommand};
 mod uci_receiver;
 pub use uci_receiver::UciReceiver;
 
-mod uci_sender;
-pub use uci_sender::{UciSender, UciSenderMessage};
+pub mod uci_sender;

--- a/src/uci/uci_receiver.rs
+++ b/src/uci/uci_receiver.rs
@@ -1,6 +1,6 @@
 use std::sync::mpsc::Sender;
 
-use crate::uci::{UciCommand, UciSender};
+use crate::uci::{UciCommand, uci_sender};
 
 /// Struct acting as a UCI receiver. It runs in its own thread and communicates with the engine via
 /// message passing. The stop and ponderhit command require their own channels since they need to be
@@ -45,7 +45,7 @@ impl UciReceiver {
             match command {
                 // Don't propagate invalid commands to the engine.
                 UciCommand::Invalid => continue,
-                UciCommand::Uci => UciSender::id(),
+                UciCommand::Uci => uci_sender::id(),
                 // Send here since main is busy.
                 UciCommand::Stop => self
                     .stop_tx

--- a/src/uci/uci_sender.rs
+++ b/src/uci/uci_sender.rs
@@ -50,7 +50,7 @@ impl UciSender {
     }
 
     /// bestmove.
-    fn best_move(mv: ChessMove, ponder_moves: Option<Vec<ChessMove>>) {
+    pub fn best_move(mv: ChessMove, ponder_moves: Option<Vec<ChessMove>>) {
         let mut msg = format!("bestmove {mv}");
 
         if let Some(ponder_moves) = ponder_moves {
@@ -64,7 +64,7 @@ impl UciSender {
     }
 
     /// General info message.
-    fn search_info(depth: u16, time: Duration, nodes: u64, pv: Vec<ChessMove>, score_cp: i64) {
+    pub fn search_info(depth: u16, time: Duration, nodes: u64, pv: Vec<ChessMove>, score_cp: i64) {
         // FIXME: seldepth, refutation, currline and score mate should be sent.
         let mut msg = format!(
             "info depth {depth} time {} nodes {nodes} nps {} score cp {score_cp}",

--- a/src/uci/uci_sender.rs
+++ b/src/uci/uci_sender.rs
@@ -1,85 +1,49 @@
-use std::{sync::mpsc::Receiver, time::Duration};
+use std::time::Duration;
 
 use chess::ChessMove;
 
-/// A UCI message sent by the engine.
-pub enum UciSenderMessage {
-    /// bestmove message.
-    BestMove(ChessMove, Option<Vec<ChessMove>>),
-    /// General info message.
-    SearchInfo(u16, Duration, u64, Vec<ChessMove>, i64),
+/// readyok.
+pub fn ready_ok() {
+    println!("readyok");
 }
 
-/// Struct acting as a UCI sender. It runs in its own thread and communicates with the engine via
-/// message passing.
-pub struct UciSender {
-    /// Channel for receiving messages from the engine.
-    message_rx: Receiver<UciSenderMessage>,
+/// id.
+pub fn id() {
+    println!("id name Rxh7+ V1.2");
+    println!("id author ComicalCache");
+    println!("uciok");
 }
 
-impl UciSender {
-    /// Creates a new UCI sender.
-    pub fn new(message_rx: Receiver<UciSenderMessage>) -> Self {
-        UciSender { message_rx }
-    }
+/// bestmove.
+pub fn best_move(mv: ChessMove, ponder_moves: Option<Vec<ChessMove>>) {
+    let mut msg = format!("bestmove {mv}");
 
-    /// Main loop, receiving messages from the engine and propagating them to UCI.
-    pub fn start(&mut self) {
-        while let Ok(msg) = self.message_rx.recv() {
-            match msg {
-                UciSenderMessage::BestMove(mv, ponder_moves) => {
-                    UciSender::best_move(mv, ponder_moves)
-                }
-                UciSenderMessage::SearchInfo(depth, time, nodes, pv, score_cp) => {
-                    UciSender::search_info(depth, time, nodes, pv, score_cp)
-                }
-            }
+    if let Some(ponder_moves) = ponder_moves {
+        msg.push_str(" ponder");
+        for ponder_mv in ponder_moves {
+            msg.push_str(format!(" {ponder_mv}").as_str());
         }
     }
 
-    /// readyok.
-    pub fn ready_ok() {
-        println!("readyok");
-    }
+    println!("{msg}");
+}
 
-    /// id.
-    pub fn id() {
-        println!("id name Rxh7+ V1.2");
-        println!("id author ComicalCache");
-        println!("uciok");
-    }
+/// General info message.
+pub fn search_info(depth: u16, time: Duration, nodes: u64, pv: Vec<ChessMove>, score_cp: i64) {
+    // FIXME: seldepth, refutation, currline and score mate should be sent.
+    let mut msg = format!(
+        "info depth {depth} time {} nodes {nodes} nps {} score cp {score_cp}",
+        time.as_millis(),
+        nodes / time.as_secs().max(1),
+    );
 
-    /// bestmove.
-    pub fn best_move(mv: ChessMove, ponder_moves: Option<Vec<ChessMove>>) {
-        let mut msg = format!("bestmove {mv}");
+    if !pv.is_empty() {
+        msg.push_str(" pv");
 
-        if let Some(ponder_moves) = ponder_moves {
-            msg.push_str(" ponder");
-            for ponder_mv in ponder_moves {
-                msg.push_str(format!(" {ponder_mv}").as_str());
-            }
+        for mv in pv {
+            msg.push_str(format!(" {mv}").as_str());
         }
-
-        println!("{msg}");
     }
 
-    /// General info message.
-    pub fn search_info(depth: u16, time: Duration, nodes: u64, pv: Vec<ChessMove>, score_cp: i64) {
-        // FIXME: seldepth, refutation, currline and score mate should be sent.
-        let mut msg = format!(
-            "info depth {depth} time {} nodes {nodes} nps {} score cp {score_cp}",
-            time.as_millis(),
-            nodes / time.as_secs().max(1),
-        );
-
-        if !pv.is_empty() {
-            msg.push_str(" pv");
-
-            for mv in pv {
-                msg.push_str(format!(" {mv}").as_str());
-            }
-        }
-
-        println!("{msg}");
-    }
+    println!("{msg}");
 }


### PR DESCRIPTION
Fixes a bug with causing a lot of unnecessary threefold repetition draws in winning positions. Only stores board hashes on position stack instead of the full board.